### PR TITLE
Bundling Files with systemjs + kendo 2016.1 still fails.

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <title>Webpack Kendoui Test</title>
+    <link rel="stylesheet" href="./css/libs/bootstrap.min.css" />
+    <link href="./css/libs/kendo/kendo.common.min.css" rel="stylesheet" type="text/css" />
+    <link href="./css/libs/kendo/kendo.bootstrap.min.css" rel="stylesheet" type="text/css" />
+    <link href="./css/app.css" rel="stylesheet" type="text/css" />
+</head>
+
+<body>
+    <div id="main">
+        <div id="tableWrapper" class="tableWrapper"></div>
+    </div>
+    <script src="js/app-dist.js"></script>
+    <!--<script src=" ../node_modules/jquery/dist/jquery.min.js "></script>-->
+    <!--<script src="../node_modules/systemjs/dist/system.js"></script>-->
+    <!--http://127.0.0.1:8887/bower_components/kendo-ui/src/js/kendo-ui/src/js/kendo.router.js-->
+    <!--<script>-->
+<!--//    System.config({-->
+<!--//        defaultJSExtensions: true,-->
+<!--//        paths: {-->
+<!--//            "kendo.*": "../bower_components/kendo-ui/src/js/kendo.*"-->
+<!--//        },-->
+<!--//        transpiler: "plugin-babel",-->
+<!--//        map: {-->
+<!--//            "plugin-babel": "../node_modules/systemjs-plugin-babel/plugin-babel.js",-->
+<!--//            'systemjs-babel-build': '../node_modules/systemjs-plugin-babel/systemjs-babel-browser.js',-->
+<!--//            jquery: '../node_modules/jquery/dist/jquery.min.js'-->
+<!--//        }-->
+<!--//    });-->
+<!--//    System.import('./js/app.js');-->
+    <!--</script>-->
+    <!--        paths: {
+        'kendo.*': "../kendo/dist/js/kendo.*.js"
+      } -->
+</body>
+
+</html>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,35 @@
+var gulp = require('gulp')
+    , path = require("path")
+    , Builder = require('systemjs-builder');
+
+
+gulp.task('default', function () {
+
+// optional constructor options
+// sets the baseURL and loads the configuration file
+    var builder = new Builder('./', {
+        defaultJSExtensions: true,
+        paths: {
+            "kendo.*": "./bower_components/kendo-ui/src/js/kendo.*"
+        },
+        transpiler: "plugin-babel",
+        map: {
+            "plugin-babel": "./node_modules/systemjs-plugin-babel/plugin-babel.js",
+            'systemjs-babel-build': './node_modules/systemjs-plugin-babel/systemjs-babel-browser.js',
+            jquery: './node_modules/jquery/dist/jquery.min.js'
+        }
+    });
+
+    builder
+        .buildStatic('src/js/app.js', './dist/js/app-dist.js')
+        .then(function () {
+            console.log('Build complete');
+        })
+        .catch(function (err) {
+            console.log('Build error');
+            console.log(err);
+        });
+
+    gulp.src('src/css/**/*',{base: './src/'})
+        .pipe(gulp.dest('./dist/'));
+});

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "babel-plugin-transform-es2015-modules-systemjs": "^6.6.5",
     "babel-preset-es2015": "^6.6.0",
     "bower": "^1.7.7",
+    "gulp": "^3.9.1",
     "systemjs": "^0.19.24",
+    "systemjs-builder": "^0.15.15",
     "systemjs-plugin-babel": "0.0.8"
   },
   "dependencies": {

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,9 @@
 # kendo-systemjs-2016
-A Kendo test for working with SystemJS; i.e. it doesn't!!
+A Kendo test for working with SystemJS; i.e. it (still) doesn't!!
+
 Update: 22/03/2016.  Telerik found the problem, which was with the wild cards that I was using to load Kendo.  I'm leaving this here for historical purposes.
+
+Update: 24/04/2016.  Attempting to bundle the files will still result in unresolved dependencies.  This was reported to telerik in a ticket and they confirmed they saw the same behavior. They suggested I contact systemjs/jspm.
 
 ###The problem
 SystemJS is not finding the dependent Kendo libraries.  It does load libraries that are loaded directly by my code.  For example,  in /src/js/app.js I am loading kendo.router.js, and SystemJS find that just find.  However, kendo.router.js then tries to load kendo.core.js, and for some reason SystemJs is unable to find that.
@@ -17,7 +20,9 @@ The code in this repository uses Node/npm to install its dependencies.  Setup in
 1. In a bash window, git clone this repository.
 1. cd to the repository folder, then issue `npm install` to download the dependencies.
 1. One of those dependencies will be Bower.  You can now use Bower to install Kendo Pro from the official Telerik Bower packages by issuing ` node_modules/.bin/bower install` at your command prompt.  You will be prompted to your Telerik ID and password at this stage, and may have to enter them twice.
-1. Open the file src/index.html in your browser in a local web server.  I use Sublime Server for this.
+1. Another one of thoese dependencies will be Gulp.  You can now use Gulp to bundle the project together by issuing `node_modules/.bin/gulp` at your command prompt.
+1. Open the file src/index.html in your browser in a local web server.  I use Sublime Server for this.   Note that this works.
+1. Open the file dist/index.html in your browser in a local web server and note that this fails with the error 'kendo.columnsorter';
 
 ###Further Notes
 SystemJS uses Babel to transpile ES6 modules into ES5.


### PR DESCRIPTION
I used your example to demonstrate how attempting to bundle kendo 2016.1 will fail.
